### PR TITLE
Fixes a crash caused by enumerating a mutable set.

### DIFF
--- a/GBStorage.m
+++ b/GBStorage.m
@@ -156,7 +156,7 @@ static NSMutableDictionary *_instances;
 -(void)saveAll {
     // call save for all keys in the cache
     NSMutableArray *evictedKeys = [NSMutableArray new];
-    for (NSString *key in self.potentiallyCachedKeys) {
+    for (NSString *key in [self.potentiallyCachedKeys copy]) {
         // save the object if it's in the cache
         if ([self _objectFromCacheForKey:key]) {
             [self save:key];


### PR DESCRIPTION
Hey, very nice little library! Multithreaded applications will run into crashes unless you create a copy of that set.

I don't know how actively you're maintaining this, but there are also potential issues with multithreaded access to mutable dictionaries -- might want to synchronize access to `_instances` at some point. That said, thanks very much for this! 
